### PR TITLE
FIX: switch to filtered motors list

### DIFF
--- a/iocBoot/templates/st.cmd.template
+++ b/iocBoot/templates/st.cmd.template
@@ -51,7 +51,7 @@ epicsEnvSet("ADS_TIME_SOURCE",  "0")
 #                         arrives in the EPICS client.
 adsAsynPortDriverConfigure("$(ASYN_PORT)", "$(IPADDR)", "$(AMSID)", "$(AMS_PORT)", "$(ADS_MAX_PARAMS)", 0, 0, "$(ADS_SAMPLE_MS)", "$(ADS_MAX_DELAY_MS)", "$(ADS_TIMEOUT_MS)", "$(ADS_TIME_SOURCE)")
 
-{% if symbols.Symbol_DUT_MotionStage %}
+{% if motors %}
 cd "$(ADS_IOC_TOP)/db"
 
 epicsEnvSet("MOTOR_PORT",     "{{motor_port}}")
@@ -87,7 +87,7 @@ asynSetTraceInfoMask("$(ASYN_PORT)", -1, 5)
 #define AMPLIFIER_ON_FLAG_WHEN_HOMING  2
 #define AMPLIFIER_ON_FLAG_USING_CNEN   4
 
-{% for motor in symbols.Symbol_DUT_MotionStage | sort(attribute='nc_axis.axis_number') %}
+{% for motor in motors | sort(attribute='nc_axis.axis_number') %}
 epicsEnvSet("AXIS_NO",         "{{motor.nc_axis.axis_number}}")
 epicsEnvSet("MOTOR_PREFIX",    "{{motor|epics_prefix}}")
 epicsEnvSet("MOTOR_NAME",      "{{motor|epics_suffix}}")


### PR DESCRIPTION
Old list can contain pointers in addition to DUTs.

Requires `pytmc >2.5.0`