### PR TITLE
FIX: attempt at fixing autosave/db files

### DIFF
--- a/iocBoot/templates/Makefile.base
+++ b/iocBoot/templates/Makefile.base
@@ -109,6 +109,9 @@ clean:
 paths:
 	@echo "Creating IOC data directory"
 	mkdir -p $(IOC_DATA_PATH)/$(IOC_NAME)/iocInfo
+	@echo "Creating autosave files directory"
+	mkdir -p "$(IOC_INSTANCE_PATH)/autosave"
+	@chmod 777 "$(IOC_INSTANCE_PATH)/autosave"
 
 summary:
 	@echo "Generating a summary for the project. Use \`make $@ PYTMC_OPTS=...\` to pass args to pytmc." > /dev/stderr

--- a/iocBoot/templates/Makefile.ioc
+++ b/iocBoot/templates/Makefile.ioc
@@ -6,6 +6,6 @@ PROJECT_PATH := {{ tsproj_path }}
 PLC = {{ plc_name }}
 
 PYTMC_OPTS = 
-PREFIX = PREFIX:
+PREFIX = PREFIX
 
 include $(IOC_TOP)/iocBoot/templates/Makefile.base

--- a/iocBoot/templates/st.cmd.template
+++ b/iocBoot/templates/st.cmd.template
@@ -20,7 +20,7 @@ epicsEnvSet("ASYN_PORT",        "{{asyn_port}}")
 epicsEnvSet("IPADDR",           "{{plc_ip}}")
 epicsEnvSet("AMSID",            "{{plc_ams_id}}")
 epicsEnvSet("AMS_PORT",         "{{plc_ads_port}}")
-epicsEnvSet("ADS_MAX_PARAMS",   "2000")
+epicsEnvSet("ADS_MAX_PARAMS",   "10000")
 epicsEnvSet("ADS_SAMPLE_MS",    "50")
 epicsEnvSet("ADS_MAX_DELAY_MS", "100")
 epicsEnvSet("ADS_TIMEOUT_MS",   "1000")
@@ -107,8 +107,8 @@ dbLoadRecords("EthercatMCdebug.template", "PREFIX=$(MOTOR_PREFIX), MOTOR_NAME=$(
 {% endfor %}
 {% endif %}
 
-dbLoadRecords("db/iocSoft.db", "IOC={{prefix}}")
-dbLoadRecords("db/save_restoreStatus.db", "P={{prefix}}{{delim}}")
+dbLoadRecords("iocSoft.db", "IOC={{prefix}}")
+dbLoadRecords("save_restoreStatus.db", "P={{prefix}}{{delim}}")
 
 cd "$(IOC_TOP)"
 
@@ -137,7 +137,10 @@ cd "$(IOC_TOP)"
 iocInit()
 
 # Start autosave backups
-create_monitor_set( "$(IOC).req", 5, "" )
+cd "$(IOC_TOP)/autosave"
+create_monitor_set( "info_positions.req", 10, "" )
+create_monitor_set( "info_settings.req", 60, "" )
+cd "$(IOC_TOP)"
 
 # All IOCs should dump some common info after initial startup.
 < /reg/d/iocCommon/All/post_linux.cmd

--- a/iocBoot/templates/st.cmd.template
+++ b/iocBoot/templates/st.cmd.template
@@ -127,8 +127,6 @@ save_restoreSet_status_prefix( "{{prefix}}{{delim}}" )
 save_restoreSet_IncompleteSetsOk( 1 )
 save_restoreSet_DatedBackupFiles( 1 )
 set_pass0_restoreFile( "info_positions.sav" )
-set_pass0_restoreFile( "info_settings.sav" )
-set_pass1_restoreFile( "info_positions.sav" )
 set_pass1_restoreFile( "info_settings.sav" )
 
 cd "$(IOC_TOP)/autosave"

--- a/iocBoot/templates/st.cmd.template
+++ b/iocBoot/templates/st.cmd.template
@@ -51,8 +51,9 @@ epicsEnvSet("ADS_TIME_SOURCE",  "0")
 #                         arrives in the EPICS client.
 adsAsynPortDriverConfigure("$(ASYN_PORT)", "$(IPADDR)", "$(AMSID)", "$(AMS_PORT)", "$(ADS_MAX_PARAMS)", 0, 0, "$(ADS_SAMPLE_MS)", "$(ADS_MAX_DELAY_MS)", "$(ADS_TIMEOUT_MS)", "$(ADS_TIME_SOURCE)")
 
-{% if motors %}
 cd "$(ADS_IOC_TOP)/db"
+
+{% if motors %}
 
 epicsEnvSet("MOTOR_PORT",     "{{motor_port}}")
 epicsEnvSet("PREFIX",         "{{prefix}}{{delim}}")
@@ -105,26 +106,32 @@ dbLoadRecords("EthercatMCdebug.template", "PREFIX=$(MOTOR_PREFIX), MOTOR_NAME=$(
 
 {% endfor %}
 {% endif %}
-{% if additional_db_files %}
+
+dbLoadRecords("db/iocSoft.db", "IOC={{prefix}}")
+dbLoadRecords("db/save_restoreStatus.db", "P={{prefix}}{{delim}}")
+
 cd "$(IOC_TOP)"
+
+{% if additional_db_files %}
 {% for db in additional_db_files %}
 dbLoadRecords("{{ db.file }}", "PORT={{ asyn_port }},PREFIX={{prefix}}{{delim}},IOCNAME=$(IOCNAME),{{ db.macros }}")
 
 {% endfor %}
 {% endif %}
-cd "$(IOC_TOP)"
-
-dbLoadRecords("db/iocSoft.db", "IOC={{prefix}}")
-dbLoadRecords("db/save_restoreStatus.db", "P={{prefix}}{{delim}}")
 
 # Setup autosave
 set_savefile_path( "$(IOC_DATA)/$(IOC)/autosave" )
 set_requestfile_path( "$(IOC_TOP)/autosave" )
+
 save_restoreSet_status_prefix( "{{prefix}}{{delim}}" )
 save_restoreSet_IncompleteSetsOk( 1 )
 save_restoreSet_DatedBackupFiles( 1 )
 set_pass0_restoreFile( "$(IOC).sav" )
 set_pass1_restoreFile( "$(IOC).sav" )
+
+cd "$(IOC_TOP)/autosave"
+makeAutosaveFiles()
+cd "$(IOC_TOP)"
 
 # Initialize the IOC and start processing records
 iocInit()

--- a/iocBoot/templates/st.cmd.template
+++ b/iocBoot/templates/st.cmd.template
@@ -126,8 +126,10 @@ set_requestfile_path( "$(IOC_TOP)/autosave" )
 save_restoreSet_status_prefix( "{{prefix}}{{delim}}" )
 save_restoreSet_IncompleteSetsOk( 1 )
 save_restoreSet_DatedBackupFiles( 1 )
-set_pass0_restoreFile( "$(IOC).sav" )
-set_pass1_restoreFile( "$(IOC).sav" )
+set_pass0_restoreFile( "info_positions.sav" )
+set_pass0_restoreFile( "info_settings.sav" )
+set_pass1_restoreFile( "info_positions.sav" )
+set_pass1_restoreFile( "info_settings.sav" )
 
 cd "$(IOC_TOP)/autosave"
 makeAutosaveFiles()
@@ -137,10 +139,8 @@ cd "$(IOC_TOP)"
 iocInit()
 
 # Start autosave backups
-cd "$(IOC_TOP)/autosave"
 create_monitor_set( "info_positions.req", 10, "" )
 create_monitor_set( "info_settings.req", 60, "" )
-cd "$(IOC_TOP)"
 
 # All IOCs should dump some common info after initial startup.
 < /reg/d/iocCommon/All/post_linux.cmd


### PR DESCRIPTION
An attempt (as the PR title says) which is untested.

Are we OK with the `.req` files being in `(st.cmd path)/autosave/`? Should they go in `$IOC_DATA` as well?

These are all questions I had just shrugged at when I wrote the initial template months ago, but they're important now.

We should try this out - someone with a working IOC, that is. @ZLLentz or @slacAdpai perhaps? 