### PR TITLE
Archive setting installation, Makefile separate steps + more

### DIFF
--- a/iocBoot/templates/Makefile.base
+++ b/iocBoot/templates/Makefile.base
@@ -18,7 +18,14 @@ PROJECT_PATH ?= $(IOC_INSTANCE_PATH)/../../$(PROJECT_NAME)/$(PROJECT_NAME).tspro
 TEMPLATE_PATH ?= $(IOC_TOP)/iocBoot/templates
 STCMD_TEMPLATE ?= st.cmd.template
 IOC_NAME := $(shell basename "$(IOC_INSTANCE_PATH)")
-IOC_DATA_PATH ?= /reg/d/iocData
+PRODUCTION_IOC ?= 0
+
+ifeq ($(PRODUCTION_IOC), 1)
+	IOC_DATA_PATH ?= /reg/d/iocData
+else
+	IOC_DATA_PATH ?= $(HOME)/iocData
+endif
+
 ARCHIVE_PATH ?= $(IOC_DATA_PATH)/archive
 BUILD_PATH ?= $(IOC_INSTANCE_PATH)/.pytmc_build
 DB_PARAMETERS ?= 'PREFIX=$(PREFIX):,IOCNAME=$$(IOCNAME)'
@@ -73,7 +80,7 @@ envPaths:
 		sed -e 's/^epicsEnvSet("IOC",.*)/epicsEnvSet("IOC","$(IOC_NAME)")/' \
 		> "$(IOC_INSTANCE_PATH)"/envPaths
 	@echo 'epicsEnvSet("IOC_TOP", "$(IOC_INSTANCE_PATH)")' >> "$(IOC_INSTANCE_PATH)"/envPaths
-
+	@echo 'epicsEnvSet("IOC_DATA", "$(IOC_DATA_PATH)")' >> "$(IOC_INSTANCE_PATH)"/envPaths
 
 install:
 	@echo ""

--- a/iocBoot/templates/Makefile.base
+++ b/iocBoot/templates/Makefile.base
@@ -19,6 +19,7 @@ TEMPLATE_PATH ?= $(IOC_TOP)/iocBoot/templates
 STCMD_TEMPLATE ?= st.cmd.template
 IOC_NAME := $(shell basename "$(IOC_INSTANCE_PATH)")
 IOC_DATA_PATH ?= /reg/d/iocData
+ARCHIVE_PATH ?= $(IOC_DATA_PATH)/archive
 BUILD_PATH ?= $(IOC_INSTANCE_PATH)/.pytmc_build
 # abspath is failing with spaces - falling back to Python here:
 pyabspath = $(shell python -c "import os, sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))" "$(1)" )
@@ -43,6 +44,69 @@ help:
 	@exit 1
 
 
+st.cmd:
+	@echo "Executing pytmc stcmd: creating st.cmd..."
+	cd "$(BUILD_PATH)" && \
+		pytmc stcmd \
+		--name "$(IOC_NAME)" \
+		--plc "$(PLC)" \
+		--template-path "$(TEMPLATE_PATH)" \
+		--template "$(STCMD_TEMPLATE)" \
+		--hashbang "$(BINARY_PATH)" \
+		--only-motor \
+		-p "$(PREFIX)" \
+		$(PYTMC_OPTS) \
+		"$(call pyabspath,$(PROJECT_PATH))" > st.cmd
+
+db:
+	@echo "Executing pytmc db: creating $(PLC).db and $(PLC).archive..."
+	cd "$(BUILD_PATH)" && \
+		pytmc db \
+		--plc "$(PLC)" \
+		"$(call pyabspath,$(PROJECT_PATH))" \
+		"$(PLC).db"
+
+envPaths:
+	@echo "* Copying envPaths and fixing IOC_TOP..."
+	@cat "$(TEMPLATE_PATH)"/envPaths | \
+		sed -e 's/^epicsEnvSet("IOC",.*)/epicsEnvSet("IOC","$(IOC_NAME)")/' \
+		> "$(IOC_INSTANCE_PATH)"/envPaths
+	@echo 'epicsEnvSet("IOC_TOP", "$(IOC_INSTANCE_PATH)")' >> "$(IOC_INSTANCE_PATH)"/envPaths
+
+
+install:
+	@echo ""
+	@echo "* Copying st.cmd and databases..."
+	@ if [ -f "$(IOC_INSTANCE_PATH)"/st.cmd ]; then \
+		echo "* Changing permissions on the old st.cmd..."; \
+		chmod +w "$(IOC_INSTANCE_PATH)/st.cmd"; \
+	fi 
+
+	@shopt -s nullglob; \
+	for filename in "$(BUILD_PATH)"/{st.cmd,*.db}; \
+	do \
+		echo "* Installing: $$(basename $$filename)"; \
+		install -p -m 0444 "$$filename" "$(IOC_INSTANCE_PATH)"; \
+	done
+
+	@chmod +x "$(IOC_INSTANCE_PATH)/st.cmd"
+
+	@shopt -s nullglob; \
+	for filename in "$(BUILD_PATH)"/*.archive; \
+	do \
+		if [ -d "$(ARCHIVE_PATH)" ]; then \
+			echo "* Installing archive file: $$(basename $$filename)"; \
+			install -p -m 0444 "$$filename" "$(ARCHIVE_PATH)"; \
+		else \
+			echo "* Warning: ${IOC_DATA_PATH}/${IOC_NAME}/iocInfo does not exist;" \
+				"copying archive file to the IOC instance path."; \
+			install -p -m 0444 "$$filename" "$(IOC_INSTANCE_PATH)"; \
+		fi; \
+	done
+
+	@cd "$(IOC_INSTANCE_PATH)"
+
+
 build:
 	@echo "-----------------------------------------------------------"
 	@echo "Build path: $(BUILD_PATH)"
@@ -56,41 +120,12 @@ build:
 	@echo ""
 
 	mkdir -p "$(BUILD_PATH)"
-	@echo "Executing pytmc..."
-	cd "$(BUILD_PATH)" && \
-		pytmc stcmd \
-		--name "$(IOC_NAME)" \
-		--plc "$(PLC)" \
-		--template-path "$(TEMPLATE_PATH)" \
-		--template "$(STCMD_TEMPLATE)" \
-		--hashbang "$(BINARY_PATH)" \
-		-p "$(PREFIX)" \
-		$(PYTMC_OPTS) \
-		"$(call pyabspath,$(PROJECT_PATH))" > st.cmd
 
-	@echo ""
-	@echo "* Copying st.cmd and databases..."
-	@ if [ -f "$(IOC_INSTANCE_PATH)"/st.cmd ]; then \
-		echo "* Changing permissions on the old st.cmd..."; \
-		chmod +w "$(IOC_INSTANCE_PATH)/st.cmd"; \
-	fi 
+	@$(MAKE) st.cmd
+	@$(MAKE) db
+	@$(MAKE) envPaths
+	@$(MAKE) install
 
-	@echo "* Copying envPaths..."
-	@cat "$(TEMPLATE_PATH)"/envPaths | \
-		sed -e 's/^epicsEnvSet("IOC",.*)/epicsEnvSet("IOC","$(IOC_NAME)")/' \
-		> "$(IOC_INSTANCE_PATH)"/envPaths
-	@echo 'epicsEnvSet("IOC_TOP", "$(IOC_INSTANCE_PATH)")' >> "$(IOC_INSTANCE_PATH)"/envPaths
-
-	@shopt -s nullglob; \
-	for filename in "$(BUILD_PATH)"/{st.cmd,*.db}; \
-	do \
-		echo "* Installing: $$(basename $$filename)"; \
-		install -p -m 0444 "$$filename" "$(IOC_INSTANCE_PATH)"; \
-	done
-
-	@chmod +x "$(IOC_INSTANCE_PATH)/st.cmd"
-
-	@cd "$(IOC_INSTANCE_PATH)"
 	@echo ""
 	@echo "Build complete."
 
@@ -100,7 +135,7 @@ clean:
 	@echo "* Cleaning..."
 	@if [ -d "$(BUILD_PATH)" ]; then \
 		shopt -s nullglob; \
-		rm -f "$(BUILD_PATH)"/st.cmd "$(BUILD_PATH)"/*.db; \
+		rm -f "$(BUILD_PATH)"/st.cmd "$(BUILD_PATH)"/*.db "$(BUILD_PATH)"/*.archive; \
 		rmdir "$(BUILD_PATH)"; \
 	fi
 	@echo "Done"
@@ -138,4 +173,4 @@ types:
 	pytmc types "$(call pyabspath,$(PROJECT_PATH))" $(PYTMC_OPTS)
 
 
-.PHONY: all build clean paths summary code outline debug types
+.PHONY: all st.cmd db envPaths install build clean paths summary code outline debug types

--- a/iocBoot/templates/Makefile.base
+++ b/iocBoot/templates/Makefile.base
@@ -21,6 +21,7 @@ IOC_NAME := $(shell basename "$(IOC_INSTANCE_PATH)")
 IOC_DATA_PATH ?= /reg/d/iocData
 ARCHIVE_PATH ?= $(IOC_DATA_PATH)/archive
 BUILD_PATH ?= $(IOC_INSTANCE_PATH)/.pytmc_build
+DB_PARAMETERS ?= 'PREFIX=$(PREFIX):,IOCNAME=$$(IOCNAME)'
 # abspath is failing with spaces - falling back to Python here:
 pyabspath = $(shell python -c "import os, sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))" "$(1)" )
 
@@ -82,14 +83,27 @@ install:
 		chmod +w "$(IOC_INSTANCE_PATH)/st.cmd"; \
 	fi 
 
-	@shopt -s nullglob; \
-	for filename in "$(BUILD_PATH)"/{st.cmd,*.db}; \
-	do \
-		echo "* Installing: $$(basename $$filename)"; \
-		install -p -m 0444 "$$filename" "$(IOC_INSTANCE_PATH)"; \
-	done
+	@if test -n `shopt -s nullglob; echo "$(BUILD_PATH)"/*.db`; then \
+		echo "* Found database files to install; creating load_plc_databases.cmd..."; \
+		find $(BUILD_PATH) -name '*.db' -print0 | \
+			PREFIX=$(PREFIX) DELIM=":" DB_PARAMETERS=$(DB_PARAMETERS) \
+			python $(TEMPLATE_PATH)/dbloads.py \
+			> "$(BUILD_PATH)/load_plc_databases.cmd"; \
+		\
+		for filename in "$(BUILD_PATH)"/*.db; \
+		do \
+			echo "* Installing: $$(basename $$filename)"; \
+			install -p -m 0444 "$$filename" "$(IOC_INSTANCE_PATH)"; \
+		done \
+	else \
+		touch "$(BUILD_PATH)/load_plc_databases.cmd"; \
+	fi
 
-	@chmod +x "$(IOC_INSTANCE_PATH)/st.cmd"
+	@echo "* Installing: st.cmd"
+	install -p -m 0555 "$(BUILD_PATH)/st.cmd" "$(IOC_INSTANCE_PATH)";
+
+	@echo "* Installing: load_plc_databases.cmd"
+	install -p -m 0444 "$(BUILD_PATH)/load_plc_databases.cmd" "$(IOC_INSTANCE_PATH)";
 
 	@shopt -s nullglob; \
 	for filename in "$(BUILD_PATH)"/*.archive; \
@@ -135,7 +149,8 @@ clean:
 	@echo "* Cleaning..."
 	@if [ -d "$(BUILD_PATH)" ]; then \
 		shopt -s nullglob; \
-		rm -f "$(BUILD_PATH)"/st.cmd "$(BUILD_PATH)"/*.db "$(BUILD_PATH)"/*.archive; \
+		rm -f "$(BUILD_PATH)"/st.cmd "$(BUILD_PATH)"/load_plc_databases.cmd \
+			  "$(BUILD_PATH)"/*.db "$(BUILD_PATH)"/*.archive; \
 		rmdir "$(BUILD_PATH)"; \
 	fi
 	@echo "Done"

--- a/iocBoot/templates/Makefile.ioc
+++ b/iocBoot/templates/Makefile.ioc
@@ -1,7 +1,7 @@
 IOC_TOP = {{ template_path.parent.parent }}
 IOC_INSTANCE_PATH := $(shell pwd)
 
-# Set the next line to 1 to move from a testing to a production IOC:
+# Set PRODUCTION_IOC to 1 to move from a testing to a production IOC:
 PRODUCTION_IOC := 0
 
 PROJECT_NAME := {{ project_name }}

--- a/iocBoot/templates/Makefile.ioc
+++ b/iocBoot/templates/Makefile.ioc
@@ -1,11 +1,14 @@
 IOC_TOP = {{ template_path.parent.parent }}
 IOC_INSTANCE_PATH := $(shell pwd)
 
-PROJECT_NAME = {{ project_name }}
-PROJECT_PATH := {{ tsproj_path }}
-PLC = {{ plc_name }}
+# Set the next line to 1 to move from a testing to a production IOC:
+PRODUCTION_IOC := 0
 
-PYTMC_OPTS = 
-PREFIX = PREFIX
+PROJECT_NAME := {{ project_name }}
+PROJECT_PATH := {{ tsproj_path }}
+PLC := {{ plc_name }}
+
+PYTMC_OPTS := 
+PREFIX := PREFIX
 
 include $(IOC_TOP)/iocBoot/templates/Makefile.base

--- a/iocBoot/templates/dbloads.py
+++ b/iocBoot/templates/dbloads.py
@@ -1,0 +1,24 @@
+'''
+Usage: dbloads.py
+Input: list of all database db_filenames, delimited by \0
+Output: list of dbLoadRecords(...) calls
+'''
+
+import os
+import sys
+
+
+def load_record_entry(db_filename):
+    db_filename = os.path.split(db_filename)[-1]
+    env.update(dict(db_filename=db_filename))
+
+    return (
+        'dbLoadRecords("{db_filename}", '
+        '"PORT=ASYN_PLC,{DB_PARAMETERS}")'
+        ''.format(**env)
+    )
+
+
+db_filenames = sys.stdin.read().strip('\0').split('\0')
+env = dict(os.environ)
+print('\n'.join(load_record_entry(fn) for fn in db_filenames))

--- a/iocBoot/templates/st.cmd.template
+++ b/iocBoot/templates/st.cmd.template
@@ -119,6 +119,8 @@ dbLoadRecords("{{ db.file }}", "PORT={{ asyn_port }},PREFIX={{prefix}}{{delim}},
 {% endfor %}
 {% endif %}
 
+## Placeholder for loading additional database files ##
+
 # Setup autosave
 set_savefile_path( "$(IOC_DATA)/$(IOC)/autosave" )
 set_requestfile_path( "$(IOC_TOP)/autosave" )

--- a/iocBoot/templates/st.cmd.template
+++ b/iocBoot/templates/st.cmd.template
@@ -112,14 +112,15 @@ dbLoadRecords("save_restoreStatus.db", "P={{prefix}}{{delim}}")
 
 cd "$(IOC_TOP)"
 
+## Database files ##
+< "$(IOC_TOP)/load_plc_databases.cmd"
+
 {% if additional_db_files %}
 {% for db in additional_db_files %}
 dbLoadRecords("{{ db.file }}", "PORT={{ asyn_port }},PREFIX={{prefix}}{{delim}},IOCNAME=$(IOCNAME),{{ db.macros }}")
 
 {% endfor %}
 {% endif %}
-
-## Placeholder for loading additional database files ##
 
 # Setup autosave
 set_savefile_path( "$(IOC_DATA)/$(IOC)/autosave" )


### PR DESCRIPTION
* Makefile now has additional steps for optional rebuilding: `make st.cmd db`
* Archive file support (copies to `/reg/g/pcds` only if available)
* Macro customization in the IOC instance `Makefile` via `DB_PARAMETERS` variable

Tried to do everything in bash, but ended up falling back to Python to create the `dbLoadRecords` calls as the syntax was driving me crazy...