### PR TITLE
FIX: remove closed_loop-locking of motor.VELO field

### DIFF
--- a/app/Db/EthercatMCreadback.template
+++ b/app/Db/EthercatMCreadback.template
@@ -1,11 +1,3 @@
-record(ao, "$(PREFIX)$(MOTOR_NAME)-CfgVELO-RB_")
-{
-    field(PREC, "$(PREC)")
-    field(DOL,  "$(PREFIX)$(MOTOR_NAME)-CfgVELO-RB CP")
-    field(OUT,  "$(PREFIX)$(MOTOR_NAME).VELO")
-    field(OMSL, "closed_loop")
-}
-
 record(ao, "$(PREFIX)$(MOTOR_NAME)-CfgVMAX-RB_")
 {
     field(PREC, "$(PREC)")


### PR DESCRIPTION
Closes #51 

Long-term, this value should be considered the default for the .VELO field, with autosave taking priority. This will be in a new issue.