### PR TITLE
FIX: IOCNAME -> IOC

### DIFF
--- a/iocBoot/templates/Makefile.base
+++ b/iocBoot/templates/Makefile.base
@@ -30,7 +30,7 @@ endif
 
 ARCHIVE_PATH ?= $(IOC_DATA_PATH)/$(IOC_NAME)/archive
 BUILD_PATH ?= $(IOC_INSTANCE_PATH)/.pytmc_build
-DB_PARAMETERS ?= 'PREFIX=$(PREFIX):,IOCNAME=$$(IOCNAME)'
+DB_PARAMETERS ?= 'PREFIX=$(PREFIX):,IOCNAME=$$(IOC),IOC=$$(IOC)'
 # abspath is failing with spaces - falling back to Python here:
 pyabspath = $(shell python -c "import os, sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))" "$(1)" )
 

--- a/iocBoot/templates/Makefile.ioc
+++ b/iocBoot/templates/Makefile.ioc
@@ -11,7 +11,7 @@ PLC := {{ plc_name }}
 PYTMC_OPTS := 
 PREFIX := PLC:$(PLC)
 
-# With two $$, as in $$(IOCNAME) below, this will be expanded in the
+# With two $$, as in $$(IOC) below, this will be expanded in the
 # environment of st.cmd:
 DB_PARAMETERS := 'PREFIX=$(PREFIX):,IOCNAME=$$(IOC),IOC=$$(IOC)'
 

--- a/iocBoot/templates/Makefile.ioc
+++ b/iocBoot/templates/Makefile.ioc
@@ -13,6 +13,6 @@ PREFIX := PLC:$(PLC)
 
 # With two $$, as in $$(IOCNAME) below, this will be expanded in the
 # environment of st.cmd:
-DB_PARAMETERS := 'PREFIX=$(PREFIX):,IOCNAME=$$(IOCNAME)'
+DB_PARAMETERS := 'PREFIX=$(PREFIX):,IOCNAME=$$(IOC),IOC=$$(IOC)'
 
 include $(IOC_TOP)/iocBoot/templates/Makefile.base

--- a/iocBoot/templates/st.cmd.template
+++ b/iocBoot/templates/st.cmd.template
@@ -5,10 +5,9 @@
 
 epicsEnvSet("ADS_IOC_TOP", "$(TOP)" )
 
-epicsEnvSet("IOCNAME", "{{name}}" )
 epicsEnvSet("ENGINEER", "{{user}}" )
 epicsEnvSet("LOCATION", "{{prefix}}" )
-epicsEnvSet("IOCSH_PS1", "$(IOCNAME)> " )
+epicsEnvSet("IOCSH_PS1", "$(IOC)> " )
 
 # Run common startup commands for linux soft IOC's
 < /reg/d/iocCommon/All/pre_linux.cmd
@@ -118,7 +117,7 @@ cd "$(IOC_TOP)"
 
 {% if additional_db_files %}
 {% for db in additional_db_files %}
-dbLoadRecords("{{ db.file }}", "PORT={{ asyn_port }},PREFIX={{prefix}}{{delim}},IOCNAME=$(IOCNAME),{{ db.macros }}")
+dbLoadRecords("{{ db.file }}", "PORT={{ asyn_port }},PREFIX={{prefix}}{{delim}},IOCNAME=$(IOC),{{ db.macros }}")
 
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Questionably includes back-compatibility for "IOCNAME" macro when including database files.

If we can confirm no one is using this, it should be removed.