### PR TITLE
MNT: bump minimum pytmc version to avoid autosave failure

### DIFF
--- a/iocBoot/templates/Makefile.base
+++ b/iocBoot/templates/Makefile.base
@@ -1,6 +1,6 @@
 ifndef IOC_TOP
 $(error IOC_TOP is not set)
-endif 
+endif
 ifndef PROJECT_NAME
 $(error PROJECT_NAME is not set)
 endif
@@ -20,7 +20,7 @@ TEMPLATE_PATH ?= $(IOC_TOP)/iocBoot/templates
 STCMD_TEMPLATE ?= st.cmd.template
 IOC_NAME := $(shell basename "$(IOC_INSTANCE_PATH)")
 PRODUCTION_IOC ?= 0
-PYTMC_MIN_VERSION ?= 2.6.0
+PYTMC_MIN_VERSION ?= 2.7.7
 
 ifeq ($(PRODUCTION_IOC), 1)
 	IOC_DATA_PATH ?= /reg/d/iocData
@@ -95,7 +95,7 @@ install:
 	@ if [ -f "$(IOC_INSTANCE_PATH)"/st.cmd ]; then \
 		echo "* Changing permissions on the old st.cmd..."; \
 		chmod +w "$(IOC_INSTANCE_PATH)/st.cmd"; \
-	fi 
+	fi
 
 	@if test -n "`shopt -s nullglob; echo "$(BUILD_PATH)"/*.db`"; then \
 		echo "* Found database files to install; creating load_plc_databases.cmd..."; \


### PR DESCRIPTION
Jing accidentally rebuilt outside of `dev_conda`, removing `PINI` and therefore re-breaking autosave - oops.

This version check is included for reasons like these and hasn't been tracking pytmc releases as well as it should.