### PR TITLE
ENH: customize callback queue size

### DIFF
--- a/iocBoot/templates/Makefile.base
+++ b/iocBoot/templates/Makefile.base
@@ -146,6 +146,7 @@ build:
 	@echo "IOC name: $(IOC_NAME)"
 	@echo "PYTMC_OPTS: $(PYTMC_OPTS)"
 	@echo "PROJECT_PATH: $(PROJECT_PATH)"
+	@echo "ARCHIVE_PATH: $(ARCHIVE_PATH)"
 	@echo "Absolute project path: " $(call pyabspath,$(PROJECT_PATH))
 	@echo "-----------------------------------------------------------"
 	@echo ""

--- a/iocBoot/templates/Makefile.base
+++ b/iocBoot/templates/Makefile.base
@@ -10,7 +10,10 @@ $(error PLC is not set)
 endif
 
 SHELL = /bin/bash
+
+# Set defaults:
 PYTMC_OPTS ?=
+PYTMC_DB_OPTS ?=
 PREFIX ?=
 HOST_ARCH ?= rhel7-x86_64
 BINARY_PATH ?= $(IOC_TOP)/bin/$(HOST_ARCH)/adsIoc
@@ -78,6 +81,7 @@ db: _check_versions
 	cd "$(BUILD_PATH)" && \
 		pytmc db \
 		--plc "$(PLC)" \
+		$(PYTMC_DB_OPTS) \
 		"$(call pyabspath,$(PROJECT_PATH))" \
 		"$(PLC).db"
 

--- a/iocBoot/templates/dbloads.py
+++ b/iocBoot/templates/dbloads.py
@@ -1,24 +1,63 @@
+#!/usr/bin/env python
 '''
 Usage: dbloads.py
 Input: list of all database db_filenames, delimited by \0
 Output: list of dbLoadRecords(...) calls
+
+Relevant environment variables:
+    * DB_PARAMETERS: parameters to pass to dbLoadRecords()
+    * QUEUE_SIZE_BASE: the minimum callback queue size
+    * QUEUE_SIZE_SCALE: total_records * scale
+
+The callback queue size will be calculated as follows:
+
+    (QUEUE_SIZE_SCALE * total_records) + QUEUE_SIZE_BASE
 '''
 
 import os
 import sys
 
 
+def count_number_of_records(db_filename):
+    """Count the number of records in `db_filename`."""
+    with open(db_filename, 'rt') as f:
+        return len(
+            [line for line in f.readlines()
+             if line.startswith('record(')]
+        )
+
+
 def load_record_entry(db_filename):
+    """Format dbLoadRecords() based on env variable DB_PARAMETERS."""
+    env = dict(os.environ)
     db_filename = os.path.split(db_filename)[-1]
-    env.update(dict(db_filename=db_filename))
+    env['db_filename'] = db_filename
 
     return (
-        'dbLoadRecords("{db_filename}", '
-        '"PORT=ASYN_PLC,{DB_PARAMETERS}")'
+        'dbLoadRecords("{db_filename}", "PORT=ASYN_PLC,{DB_PARAMETERS}")'
         ''.format(**env)
     )
 
 
-db_filenames = sys.stdin.read().strip('\0').split('\0')
-env = dict(os.environ)
-print('\n'.join(load_record_entry(fn) for fn in db_filenames))
+def main():
+    db_filenames = sys.stdin.read().strip('\0').split('\0')
+
+    if db_filenames:
+        total_records = sum(count_number_of_records(fn) for fn in db_filenames)
+    else:
+        total_records = 0
+
+    # Multiply the number of records by the scale:
+    queue_size_scale = int(os.environ.get('QUEUE_SIZE_SCALE', '2'))
+
+    # The minimum size of the queue, outside of those for additional records:
+    queue_size_base = int(os.environ.get('QUEUE_SIZE_BASE', '2000'))
+    queue_size = queue_size_scale * total_records + queue_size_base
+
+    print('# Total records: {0}'.format(total_records))
+    print('callbackSetQueueSize({0})'.format(queue_size))
+    print('\n'.join(load_record_entry(fn) for fn in db_filenames))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Unimportant details

Going through this, I see why we didn't dynamically set the ADS parameters. The st.cmd generation and database generation are broken up into a few steps which don't really know about the other, making it more confusing than it needs to be. That can be redone down the line without incurring much risk except keeping backward-compatibility without annoying everyone too much.

For some odd reason the `dbloads.py` is Python 2-friendly. I'm keeping it that way for now.

## Important details
* Provide enough `Makefile`-level hooks to configure the callback size dynamically, based on a minimum value + (optionally scaled) number of records. 
* This is almost definitely overkill. If we end up never having to tweak this, we could hard-code the environment variables.
* Hopefully closes #68 

## Pork barrel
* Add PYTMC_DB_OPTS to close #49 
* Show `ARCHIVE_PATH` when building, indicating `PRODUCTION_IOC` setting