### PR TITLE
MNT: add DIR/OFF to pass0 autosave to fix startup bugs

### DIFF
--- a/app/Db/EthercatMC.template
+++ b/app/Db/EthercatMC.template
@@ -28,7 +28,7 @@ record(motor,"$(PREFIX)$(MOTOR_NAME)")
     field(TWV,"$(TWV=1)")
     field(VBAS,"$(VBAS=0)")
     field(VELO,"$(VELO=0)")
-    info(autosaveFields_pass0, "VAL DVAL")
+    info(autosaveFields_pass0, "VAL DVAL DIR OFF")
     info(autosaveFields, "ACCL DESC DHLM DIR DLLM EGU ERES FOFF HLM LLM MRES OFF PREC RDBD VBAS VELO VMAX")
     info(archive, "ACCL DESC DHLM DIR DLLM DVAL EGU FOFF HLM LLM OFF PREC RDBD RBV RRBV RVAL SPDB VAL VBAS VELO VMAX")
 }


### PR DESCRIPTION
Current behavior: RBV/VAL do not represent the DIR/OFF values until the first move, or first update to DIR/OFF
After this change: RBV/VAL correctly represent the DIR/OFF at startup. Simply initializing with the correct values made everything else work out correctly.

closes #73