### PR TITLE
ENH: add (untested) exceed count monitoring

### DIFF
--- a/app/Db/TwinCAT_TaskInfo.db
+++ b/app/Db/TwinCAT_TaskInfo.db
@@ -86,7 +86,7 @@ info(archive, "monitor 1: VAL")
 
 record(longin, "$(PREFIX):TaskInfo:1:ExceedCount_RBV"){
  field(DTYP, "asynInt32")
- field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK1_PORT=350)/POLL_RATE=1/.ADR.16#F200,16#100,4,19?")
+ field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK1_PORT=350)/TS_MS=1000/.ADR.16#F200,16#100,4,19?")
  field(PINI, "1")
  field(SCAN, "I/O Intr")
  field(TSE, "-2")
@@ -204,7 +204,7 @@ info(archive, "monitor 1: VAL")
 
 record(longin, "$(PREFIX):TaskInfo:2:ExceedCount_RBV"){
  field(DTYP, "asynInt32")
- field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK2_PORT=351)/POLL_RATE=1/.ADR.16#F200,16#100,4,19?")
+ field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK2_PORT=351)/TS_MS=1000/.ADR.16#F200,16#100,4,19?")
  field(PINI, "1")
  field(SCAN, "I/O Intr")
  field(TSE, "-2")
@@ -321,7 +321,7 @@ info(archive, "monitor 1: VAL")
 
 record(longin, "$(PREFIX):TaskInfo:3:ExceedCount_RBV"){
  field(DTYP, "asynInt32")
- field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK3_PORT=352)/POLL_RATE=1/.ADR.16#F200,16#100,4,19?")
+ field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK3_PORT=352)/TS_MS=1000/.ADR.16#F200,16#100,4,19?")
  field(PINI, "1")
  field(SCAN, "I/O Intr")
  field(TSE, "-2")

--- a/app/Db/TwinCAT_TaskInfo.db
+++ b/app/Db/TwinCAT_TaskInfo.db
@@ -1,4 +1,3 @@
-
 record(longin,"$(PREFIX):TaskInfo:1:CycleTime"){
  field(PINI, "1")
  field(TSE, -2)
@@ -83,6 +82,15 @@ record(bi,"$(PREFIX):TaskInfo:1:CycleTimeExceeded"){
  field(ZNAM,"FALSE")
  field(ONAM,"TRUE")
 info(archive, "monitor 1: VAL")
+}
+
+record(longin, "$(PREFIX):TaskInfo:1:ExceedCount_RBV"){
+ field(DTYP, "asynInt32")
+ field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK1_PORT=350)/POLL_RATE=1/.ADR.16#F200,16#100,32,19?")
+ field(PINI, "1")
+ field(SCAN, "I/O Intr")
+ field(TSE, "-2")
+ info(archive, "monitor 1: VAL")
 }
 
 record(bi,"$(PREFIX):TaskInfo:1:InCallAfterOutputUpdate"){
@@ -194,6 +202,15 @@ record(bi,"$(PREFIX):TaskInfo:2:CycleTimeExceeded"){
 info(archive, "monitor 1: VAL")
 }
 
+record(longin, "$(PREFIX):TaskInfo:2:ExceedCount_RBV"){
+ field(DTYP, "asynInt32")
+ field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK2_PORT=351)/POLL_RATE=1/.ADR.16#F200,16#100,32,19?")
+ field(PINI, "1")
+ field(SCAN, "I/O Intr")
+ field(TSE, "-2")
+ info(archive, "monitor 1: VAL")
+}
+
 record(bi,"$(PREFIX):TaskInfo:2:InCallAfterOutputUpdate"){
  field(PINI, "1")
  field(TSE, -2)
@@ -302,6 +319,15 @@ record(bi,"$(PREFIX):TaskInfo:3:CycleTimeExceeded"){
 info(archive, "monitor 1: VAL")
 }
 
+record(longin, "$(PREFIX):TaskInfo:3:ExceedCount_RBV"){
+ field(DTYP, "asynInt32")
+ field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK3_PORT=352)/POLL_RATE=1/.ADR.16#F200,16#100,32,19?")
+ field(PINI, "1")
+ field(SCAN, "I/O Intr")
+ field(TSE, "-2")
+ info(archive, "monitor 1: VAL")
+}
+
 record(bi,"$(PREFIX):TaskInfo:3:InCallAfterOutputUpdate"){
  field(PINI, "1")
  field(TSE, -2)
@@ -323,4 +349,3 @@ record(bi,"$(PREFIX):TaskInfo:3:RTViolation"){
  field(ONAM,"TRUE")
 info(archive, "monitor 1: VAL")
 }
-

--- a/app/Db/TwinCAT_TaskInfo.db
+++ b/app/Db/TwinCAT_TaskInfo.db
@@ -86,7 +86,7 @@ info(archive, "monitor 1: VAL")
 
 record(longin, "$(PREFIX):TaskInfo:1:ExceedCount_RBV"){
  field(DTYP, "asynInt32")
- field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK1_PORT=350)/POLL_RATE=1/.ADR.16#F200,16#100,32,19?")
+ field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK1_PORT=350)/POLL_RATE=1/.ADR.16#F200,16#100,4,19?")
  field(PINI, "1")
  field(SCAN, "I/O Intr")
  field(TSE, "-2")
@@ -204,7 +204,7 @@ info(archive, "monitor 1: VAL")
 
 record(longin, "$(PREFIX):TaskInfo:2:ExceedCount_RBV"){
  field(DTYP, "asynInt32")
- field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK2_PORT=351)/POLL_RATE=1/.ADR.16#F200,16#100,32,19?")
+ field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK2_PORT=351)/POLL_RATE=1/.ADR.16#F200,16#100,4,19?")
  field(PINI, "1")
  field(SCAN, "I/O Intr")
  field(TSE, "-2")
@@ -321,7 +321,7 @@ info(archive, "monitor 1: VAL")
 
 record(longin, "$(PREFIX):TaskInfo:3:ExceedCount_RBV"){
  field(DTYP, "asynInt32")
- field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK3_PORT=352)/POLL_RATE=1/.ADR.16#F200,16#100,32,19?")
+ field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK3_PORT=352)/POLL_RATE=1/.ADR.16#F200,16#100,4,19?")
  field(PINI, "1")
  field(SCAN, "I/O Intr")
  field(TSE, "-2")


### PR DESCRIPTION
Closes #75 

**Untested**

AMS Port 350 is commonly the first PLC task, then 351 and up.
But that's not always the case! For example on lfe-optics:
```
16:                             <Task Id="3" Priority="20" CycleTime="100000" AmsPort="350">
19:                             <Task Id="6" Priority="3" CycleTime="10000" AmsPort="351" AdtTasks="true">
22:                             <Task Id="7" Priority="1" CycleTime="20000" AmsPort="352" AdtTasks="true">
```

I think being able to see _any_ exceed count, even if it may not match up with the task number, is probably a good thing.