### PR TITLE
ENH: bump to the newest version of the ads module

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -11,7 +11,7 @@ IOCADMIN_MODULE_VERSION   = R3.1.15-1.10.0
 ASYN_MODULE_VERSION       = R4.35-0.0.1
 MOTOR_MODULE_VERSION      = R6.9-ess-0.0.1
 ETHERCATMC_MODULE_VERSION = R2.1.0-0.1.2
-ADS_MODULE_VERSION        = R2.0.0-0.0.6
+ADS_MODULE_VERSION        = R2.0.0-0.0.7
 CAPUTLOG_MODULE_VERSION   = R3.7-1.0.0
 
 # ============================================================


### PR DESCRIPTION
See https://github.com/pcdshub/twincat-ads/releases/tag/R2.0.0-0.0.7

I'll test this really quick before merging