### PR TITLE
FIX: evaluate pytmc dynamic version to str before passing to distutils

### DIFF
--- a/iocBoot/templates/Makefile.base
+++ b/iocBoot/templates/Makefile.base
@@ -76,7 +76,7 @@ help:
 
 
 _check_versions:
-	@python -c "import sys, pytmc, distutils.version; print('* Found pytmc v', pytmc.__version__); sys.exit(not (distutils.version.LooseVersion(pytmc.__version__) >= distutils.version.LooseVersion('$(PYTMC_MIN_VERSION)')))" || (echo "A newer pytmc is required: >= $(PYTMC_MIN_VERSION)" 2> /dev/null && exit 1)
+	@python -c "import sys, pytmc, distutils.version; print('* Found pytmc v', pytmc.__version__); sys.exit(not (distutils.version.LooseVersion(str(pytmc.__version__)) >= distutils.version.LooseVersion('$(PYTMC_MIN_VERSION)')))" || (echo "A newer pytmc is required: >= $(PYTMC_MIN_VERSION)" 2> /dev/null && exit 1)
 
 st.cmd: _check_versions
 	@echo "Executing pytmc template: creating st.cmd and database files..."


### PR DESCRIPTION
Reported by @nrwslac and related to the new version handling I introduced
```
* Found pytmc v 2.15.0
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.7.0/lib/python3.9/site-packages/setuptools/_distutils/version.py", line 54, in __init__
    self.parse(vstring)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.7.0/lib/python3.9/site-packages/setuptools/_distutils/version.py", line 328, in parse
    components = [x for x in self.component_re.split(vstring) if x and x != '.']
TypeError: expected string or bytes-like object
A newer pytmc is required: >= 2.14.0
```