### PR TITLE
FIX: task index and task AMS port

### DIFF
--- a/app/Db/TwinCAT_TaskInfo.db
+++ b/app/Db/TwinCAT_TaskInfo.db
@@ -5,7 +5,7 @@ record(longin,"$(PREFIX):TaskInfo:$(IDX):CycleTime"){
  field(DTYP, "asynInt32")
  field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].CycleTime?")
  field(SCAN,"I/O Intr")
-info(archive, "monitor 1: VAL")
+ info(archive, "monitor 1: VAL")
 }
 
 record(longin,"$(PREFIX):TaskInfo:$(IDX):Priority"){
@@ -22,9 +22,9 @@ record(waveform,"$(PREFIX):TaskInfo:$(IDX):TaskName"){
  field(TSE, -2)
  field(DTYP, "asynInt8ArrayIn")
  field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].TaskName?")
-  field(NELM,63)
-  field(SCAN,"I/O Intr")
-  field(FTVL,"CHAR")
+ field(NELM,63)
+ field(SCAN,"I/O Intr")
+ field(FTVL,"CHAR")
  info(archive, "monitor 1: VAL")
 }
 
@@ -32,8 +32,8 @@ record(waveform,"$(PREFIX):TaskInfo:$(IDX):TaskName"){
 record(longin,"$(PREFIX):TaskInfo:$(IDX):AdsPort"){
  field(DTYP, "asynInt32")
  field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].AdsPort?")
- info(archive, "monitor 1: VAL")
  field(SCAN,"I/O Intr")
+ info(archive, "monitor 1: VAL")
 }
 
 record(longin,"$(PREFIX):TaskInfo:$(IDX):CycleCount"){
@@ -42,7 +42,7 @@ record(longin,"$(PREFIX):TaskInfo:$(IDX):CycleCount"){
  field(DTYP, "asynInt32")
  field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].CycleCount?")
  field(SCAN,"I/O Intr")
-info(archive, "monitor 1: VAL")
+ info(archive, "monitor 1: VAL")
 }
 
 record(longin,"$(PREFIX):TaskInfo:$(IDX):DcTaskTime"){
@@ -51,7 +51,7 @@ record(longin,"$(PREFIX):TaskInfo:$(IDX):DcTaskTime"){
  field(DTYP, "asynInt32")
  field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].DcTaskTime?")
  field(SCAN,"I/O Intr")
-info(archive, "monitor 1: VAL")
+ info(archive, "monitor 1: VAL")
 }
 
 record(longin,"$(PREFIX):TaskInfo:$(IDX):LastExecTime"){
@@ -60,7 +60,7 @@ record(longin,"$(PREFIX):TaskInfo:$(IDX):LastExecTime"){
  field(DTYP, "asynInt32")
  field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].LastExecTime?")
  field(SCAN,"I/O Intr")
-info(archive, "monitor 1: VAL")
+ info(archive, "monitor 1: VAL")
 }
 
 record(bi,"$(PREFIX):TaskInfo:$(IDX):FirstCycle"){
@@ -71,7 +71,7 @@ record(bi,"$(PREFIX):TaskInfo:$(IDX):FirstCycle"){
  field(SCAN,"I/O Intr")
  field(ZNAM,"FALSE")
  field(ONAM,"TRUE")
-info(archive, "monitor 1: VAL")
+ info(archive, "monitor 1: VAL")
 }
 
 record(bi,"$(PREFIX):TaskInfo:$(IDX):CycleTimeExceeded"){
@@ -82,7 +82,7 @@ record(bi,"$(PREFIX):TaskInfo:$(IDX):CycleTimeExceeded"){
  field(SCAN,"I/O Intr")
  field(ZNAM,"FALSE")
  field(ONAM,"TRUE")
-info(archive, "monitor 1: VAL")
+ info(archive, "monitor 1: VAL")
 }
 
 record(longin, "$(PREFIX):TaskInfo:$(IDX):ExceedCount_RBV"){
@@ -102,7 +102,7 @@ record(bi,"$(PREFIX):TaskInfo:$(IDX):InCallAfterOutputUpdate"){
  field(SCAN,"I/O Intr")
  field(ZNAM,"FALSE")
  field(ONAM,"TRUE")
-info(archive, "monitor 1: VAL")
+ info(archive, "monitor 1: VAL")
 }
 
 record(bi,"$(PREFIX):TaskInfo:$(IDX):RTViolation"){
@@ -113,5 +113,5 @@ record(bi,"$(PREFIX):TaskInfo:$(IDX):RTViolation"){
  field(SCAN,"I/O Intr")
  field(ZNAM,"FALSE")
  field(ONAM,"TRUE")
-info(archive, "monitor 1: VAL")
+ info(archive, "monitor 1: VAL")
 }

--- a/app/Db/TwinCAT_TaskInfo.db
+++ b/app/Db/TwinCAT_TaskInfo.db
@@ -87,7 +87,7 @@ record(bi,"$(PREFIX):TaskInfo:$(IDX):CycleTimeExceeded"){
 
 record(longin, "$(PREFIX):TaskInfo:$(IDX):ExceedCount_RBV"){
  field(DTYP, "asynInt32")
- field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK1_PORT=350)/TS_MS=1000/.ADR.16#F200,16#100,4,19?")
+ field(INP, "@asyn($(PORT),0,1)ADSPORT=$(TASK_PORT=350)/TS_MS=1000/.ADR.16#F200,16#100,4,19?")
  field(PINI, "1")
  field(SCAN, "I/O Intr")
  field(TSE, "-2")

--- a/app/Db/TwinCAT_TaskInfo.db
+++ b/app/Db/TwinCAT_TaskInfo.db
@@ -3,7 +3,7 @@ record(longin,"$(PREFIX):TaskInfo:$(IDX):CycleTime"){
  field(PINI, "1")
  field(TSE, -2)
  field(DTYP, "asynInt32")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].CycleTime?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].CycleTime?")
  field(SCAN,"I/O Intr")
 info(archive, "monitor 1: VAL")
 }
@@ -12,7 +12,7 @@ record(longin,"$(PREFIX):TaskInfo:$(IDX):Priority"){
  field(PINI, "1")
  field(TSE, -2)
  field(DTYP, "asynInt32")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].Priority?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].Priority?")
  field(SCAN,"I/O Intr")
  info(archive, "monitor 1: VAL")
 }
@@ -21,7 +21,7 @@ record(waveform,"$(PREFIX):TaskInfo:$(IDX):TaskName"){
  field(PINI, "1")
  field(TSE, -2)
  field(DTYP, "asynInt8ArrayIn")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].TaskName?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].TaskName?")
   field(NELM,63)
   field(SCAN,"I/O Intr")
   field(FTVL,"CHAR")
@@ -31,7 +31,7 @@ record(waveform,"$(PREFIX):TaskInfo:$(IDX):TaskName"){
 
 record(longin,"$(PREFIX):TaskInfo:$(IDX):AdsPort"){
  field(DTYP, "asynInt32")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].AdsPort?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].AdsPort?")
  info(archive, "monitor 1: VAL")
  field(SCAN,"I/O Intr")
 }
@@ -40,7 +40,7 @@ record(longin,"$(PREFIX):TaskInfo:$(IDX):CycleCount"){
  field(PINI, "1")
  field(TSE, -2)
  field(DTYP, "asynInt32")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].CycleCount?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].CycleCount?")
  field(SCAN,"I/O Intr")
 info(archive, "monitor 1: VAL")
 }
@@ -49,7 +49,7 @@ record(longin,"$(PREFIX):TaskInfo:$(IDX):DcTaskTime"){
  field(PINI, "1")
  field(TSE, -2)
  field(DTYP, "asynInt32")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].DcTaskTime?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].DcTaskTime?")
  field(SCAN,"I/O Intr")
 info(archive, "monitor 1: VAL")
 }
@@ -58,7 +58,7 @@ record(longin,"$(PREFIX):TaskInfo:$(IDX):LastExecTime"){
  field(PINI, "1")
  field(TSE, -2)
  field(DTYP, "asynInt32")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].LastExecTime?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].LastExecTime?")
  field(SCAN,"I/O Intr")
 info(archive, "monitor 1: VAL")
 }
@@ -67,7 +67,7 @@ record(bi,"$(PREFIX):TaskInfo:$(IDX):FirstCycle"){
  field(PINI, "1")
  field(TSE, -2)
  field(DTYP, "asynInt32")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].FirstCycle?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].FirstCycle?")
  field(SCAN,"I/O Intr")
  field(ZNAM,"FALSE")
  field(ONAM,"TRUE")
@@ -78,7 +78,7 @@ record(bi,"$(PREFIX):TaskInfo:$(IDX):CycleTimeExceeded"){
  field(PINI, "1")
  field(TSE, -2)
  field(DTYP, "asynInt32")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].CycleTimeExceeded?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].CycleTimeExceeded?")
  field(SCAN,"I/O Intr")
  field(ZNAM,"FALSE")
  field(ONAM,"TRUE")
@@ -98,7 +98,7 @@ record(bi,"$(PREFIX):TaskInfo:$(IDX):InCallAfterOutputUpdate"){
  field(PINI, "1")
  field(TSE, -2)
  field(DTYP, "asynInt32")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].InCallAfterOutputUpdate?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].InCallAfterOutputUpdate?")
  field(SCAN,"I/O Intr")
  field(ZNAM,"FALSE")
  field(ONAM,"TRUE")
@@ -109,7 +109,7 @@ record(bi,"$(PREFIX):TaskInfo:$(IDX):RTViolation"){
  field(PINI, "1")
  field(TSE, -2)
  field(DTYP, "asynInt32")
- field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[1].RTViolation?")
+ field(INP,  "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/TwinCAT_SystemInfoVarList._TaskInfo[$(IDX)].RTViolation?")
  field(SCAN,"I/O Intr")
  field(ZNAM,"FALSE")
  field(ONAM,"TRUE")

--- a/iocBoot/templates/st.cmd.template
+++ b/iocBoot/templates/st.cmd.template
@@ -182,7 +182,7 @@ dbLoadRecords("caPutLog.db", "IOC=$(IOC)")
 
 ## TwinCAT task, application, and project information databases ##
 {% for priority, (_, task) in plc.instance.task_pous.items() %}
-dbLoadRecords("TwinCAT_TaskInfo.db", "PORT=$(ASYN_PORT),PREFIX={{prefix}},IDX={{task.array_index}}")
+dbLoadRecords("TwinCAT_TaskInfo.db", "PORT=$(ASYN_PORT),PREFIX={{prefix}},IDX={{task.array_index}},TASK_PORT={{ task.attributes.AmsPort }}")
 {% endfor %}
 dbLoadRecords("TwinCAT_AppInfo.db", "PORT=$(ASYN_PORT), PREFIX={{prefix}}")
 


### PR DESCRIPTION
Closes #100 

Generated IOC and it looked OK, but otherwise untested.
(`dbLoadRecords("TwinCAT_TaskInfo.db", "PORT=$(ASYN_PORT),PREFIX=PLC:KFE:MOTION,IDX=1,TASK_PORT=350")`)