### PR TITLE
FIX: allow pytmc to be on the path but not installed

### DIFF
--- a/iocBoot/templates/Makefile.base
+++ b/iocBoot/templates/Makefile.base
@@ -77,7 +77,8 @@ help:
 
 
 _check_versions:
-	@$(PYTHON) -c "import sys, pytmc, distutils.version; print('* Found pytmc v', pytmc.__version__); sys.exit(not (distutils.version.LooseVersion(str(pytmc.__version__)) >= distutils.version.LooseVersion('$(PYTMC_MIN_VERSION)')))" || (echo "A newer pytmc is required: >= $(PYTMC_MIN_VERSION)" 2> /dev/null && exit 1)
+	@echo "* Found pytmc v$(shell pytmc --version)"
+	@$(PYTHON) -c "import sys, distutils.version; sys.exit(not (distutils.version.LooseVersion('$(shell pytmc --version)') >= distutils.version.LooseVersion('$(PYTMC_MIN_VERSION)')))" || (echo "A newer pytmc is required: >= $(PYTMC_MIN_VERSION)" 2> /dev/null && exit 1)
 
 st.cmd: _check_versions
 	@echo "Executing pytmc template: creating st.cmd and database files..."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
For cases where pytmc is on the path, but not installed in the python environment that is on the path, makefile.base is now usable. There is no degradation in usage for installed pytmc.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In my new no-sourcing-environments scheme, this wasn't quite working.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with both setups. I made sure a `make` would succeed if and only if the pytmc version was sufficiently high. To do these tests I was also modifying the PYTMC_MIN_VERSION variable as needed.

No install (ctrlenv):

<details>

```
$ make
-----------------------------------------------------------
Build path: /cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build
PLC: tc_mot_example
IOC name: ioc-tc-mot-example (* Does this match IOC Manager? *)
PYTMC_OPTS: 
PROJECT_PATH: ../../lcls-plc-example-motion/lcls-plc-example-motion.tsproj
Absolute project path:  /cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/lcls-plc-example-motion/lcls-plc-example-motion.tsproj
-----------------------------------------------------------


mkdir -p "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build"
make[1]: Entering directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
* Found pytmc v2.20.0
Executing pytmc template: creating st.cmd and database files...
cd "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build" && \
        pytmc template \
        --macro prefix="PLC:TST:MOT" \
        --macro plc="tc_mot_example" \
        --macro ads_ioc_name="ioc-tc-mot-example" \
        --macro user="zlentz" \
        --macro hashbang="/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/ioc-common-ads-ioc/bin/rhel7-x86_64/adsIoc" \
        --macro db_parameters='PREFIX=PLC:TST:MOT:,IOCNAME=$(IOC),IOC=$(IOC)' \
        --macro queue_size_base=2000 \
        --macro queue_size_scale=2 \
        --macro pv_delimiter=':' \
        --macro plc_hostname_override='' \
        --macro plc_ams_net_id_override='' \
        --macro ignore_linter_errors='0' \
        --macro ioc_host_ip_regex='^172.*$' \
        --macro add_plc_route='1' \
        --macro production_ioc='0' \
        --macro additional_db_files='' \
        --template "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/ioc-common-ads-ioc/iocBoot/templates/st.cmd.template":"st.cmd" \
         \
         \
        "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/lcls-plc-example-motion/lcls-plc-example-motion.tsproj"
make[1]: Leaving directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
make[1]: Entering directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
* Copying envPaths and fixing variables...
make[1]: Leaving directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
make[1]: Entering directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'

* Copying st.cmd and databases...
* Changing permissions on the old st.cmd...
* Found database files to install...
* Installing: tc_mot_example.db
* Installing: st.cmd
install -p -m 0555 "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build/st.cmd" "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example";
make[1]: Leaving directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'

Build complete.

* Cleaning...
Done
zlentz@psbuild-rocky9-01:~/.../iocBoot/ioc-tc-mot-example(master +)$ make
-----------------------------------------------------------
Build path: /cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build
PLC: tc_mot_example
IOC name: ioc-tc-mot-example (* Does this match IOC Manager? *)
PYTMC_OPTS: 
PROJECT_PATH: ../../lcls-plc-example-motion/lcls-plc-example-motion.tsproj
Absolute project path:  /cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/lcls-plc-example-motion/lcls-plc-example-motion.tsproj
-----------------------------------------------------------


mkdir -p "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build"
make[1]: Entering directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
* Found pytmc v2.20.0
A newer pytmc is required: >= 2.21.0
make[1]: *** [/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/ioc-common-ads-ioc/iocBoot/templates/Makefile.base:81: _check_versions] Error 1
make[1]: Leaving directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
make: *** [/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/ioc-common-ads-ioc/iocBoot/templates/Makefile.base:165: build] Error 2
```

</details>

Yes install (pcds_conda)

<details>

```
(pcds-6.1.0)zlentz@psbuild-rocky9-01:~/.../iocBoot/ioc-tc-mot-example(master +)$ make
-----------------------------------------------------------
Build path: /cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build
PLC: tc_mot_example
IOC name: ioc-tc-mot-example (* Does this match IOC Manager? *)
PYTMC_OPTS: 
PROJECT_PATH: ../../lcls-plc-example-motion/lcls-plc-example-motion.tsproj
Absolute project path:  /cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/lcls-plc-example-motion/lcls-plc-example-motion.tsproj
-----------------------------------------------------------


mkdir -p "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build"
make[1]: Entering directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
* Found pytmc v2.19.1
<string>:1: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
Executing pytmc template: creating st.cmd and database files...
cd "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build" && \
        pytmc template \
        --macro prefix="PLC:TST:MOT" \
        --macro plc="tc_mot_example" \
        --macro ads_ioc_name="ioc-tc-mot-example" \
        --macro user="zlentz" \
        --macro hashbang="/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/ioc-common-ads-ioc/bin/rhel7-x86_64/adsIoc" \
        --macro db_parameters='PREFIX=PLC:TST:MOT:,IOCNAME=$(IOC),IOC=$(IOC)' \
        --macro queue_size_base=2000 \
        --macro queue_size_scale=2 \
        --macro pv_delimiter=':' \
        --macro plc_hostname_override='' \
        --macro plc_ams_net_id_override='' \
        --macro ignore_linter_errors='0' \
        --macro ioc_host_ip_regex='^172.*$' \
        --macro add_plc_route='1' \
        --macro production_ioc='0' \
        --macro additional_db_files='' \
        --template "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/ioc-common-ads-ioc/iocBoot/templates/st.cmd.template":"st.cmd" \
         \
         \
        "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/lcls-plc-example-motion/lcls-plc-example-motion.tsproj"
WARNING:pytmc.parser:Pytmc failed to figure out what to do with: /cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/lcls-plc-example-motion/_Config/NC/NC.xti
Traceback (most recent call last):
  File "/cds/group/pcds/pyps/conda/py312/envs/pcds-6.1.0/lib/python3.12/site-packages/pytmc/parser.py", line 2263, in _pre_load_xti_files
    key = get_key(xti_filename, xti)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cds/group/pcds/pyps/conda/py312/envs/pcds-6.1.0/lib/python3.12/site-packages/pytmc/parser.py", line 2245, in get_key
    raise ValueError(f"Hmm: {candidates}")
ValueError: Hmm: [(<class 'pytmc.parser.Image'>, '1', 'nc.xti'), (<class 'pytmc.parser.Axis'>, '1', 'nc.xti'), (<class 'pytmc.parser.Axis'>, '2', 'nc.xti'), (<class 'pytmc.parser.Axis'>, '3', 'nc.xti'), (<class 'pytmc.parser.Axis'>, '4', 'nc.xti'), (<class 'pytmc.parser.Axis'>, '5', 'nc.xti'), (<class 'pytmc.parser.Axis'>, '6', 'nc.xti'), (<class 'pytmc.parser.Axis'>, '7', 'nc.xti'), (<class 'pytmc.parser.Axis'>, '8', 'nc.xti'), (<class 'pytmc.parser.Axis'>, '9', 'nc.xti'), (<class 'pytmc.parser.Axis'>, '10', 'nc.xti')]
WARNING:pytmc.parser:Pytmc failed to figure out what to do with: /cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/lcls-plc-example-motion/_Config/PLC/tc_mot_example.xti
Traceback (most recent call last):
  File "/cds/group/pcds/pyps/conda/py312/envs/pcds-6.1.0/lib/python3.12/site-packages/pytmc/parser.py", line 2263, in _pre_load_xti_files
    key = get_key(xti_filename, xti)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cds/group/pcds/pyps/conda/py312/envs/pcds-6.1.0/lib/python3.12/site-packages/pytmc/parser.py", line 2245, in get_key
    raise ValueError(f"Hmm: {candidates}")
ValueError: Hmm: [(<class 'pytmc.parser.Instance'>, '#x08502000', 'tc_mot_example.xti'), (<class 'pytmc.parser.POU'>, '{7b41e58a-08f0-4959-90b4-af08ef5cbf10}', 'tc_mot_example.xti'), (<class 'pytmc.parser.GVL'>, '{9b9d6ea6-28e0-43fe-bc83-62be23c2a739}', 'tc_mot_example.xti'), (<class 'pytmc.parser.DUT'>, '{751a5e77-d869-49d5-873f-f68eb186a084}', 'tc_mot_example.xti'), (<class 'pytmc.parser.Name'>, '0', 'tc_mot_example.xti'), (<class 'pytmc.parser.Name'>, '1', 'tc_mot_example.xti'), (<class 'pytmc.parser.Name'>, '2', 'tc_mot_example.xti'), (<class 'pytmc.parser.Name'>, '3', 'tc_mot_example.xti'), (<class 'pytmc.parser.Name'>, '4', 'tc_mot_example.xti')]
make[1]: Leaving directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
make[1]: Entering directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
* Copying envPaths and fixing variables...
make[1]: Leaving directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
make[1]: Entering directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'

* Copying st.cmd and databases...
* Changing permissions on the old st.cmd...
* Found database files to install...
* Installing: tc_mot_example.db
* Installing: st.cmd
install -p -m 0555 "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build/st.cmd" "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example";
make[1]: Leaving directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'

Build complete.

* Cleaning...
Done
(pcds-6.1.0)zlentz@psbuild-rocky9-01:~/.../iocBoot/ioc-tc-mot-example(master +)$ ls
envPaths  load_plc_databases.cmd  Makefile  st.cmd  tc_mot_example.archive  tc_mot_example.db  tc_mot_example.db.archive
(pcds-6.1.0)zlentz@psbuild-rocky9-01:~/.../iocBoot/ioc-tc-mot-example(master +)$ make
-----------------------------------------------------------
Build path: /cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build
PLC: tc_mot_example
IOC name: ioc-tc-mot-example (* Does this match IOC Manager? *)
PYTMC_OPTS: 
PROJECT_PATH: ../../lcls-plc-example-motion/lcls-plc-example-motion.tsproj
Absolute project path:  /cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/lcls-plc-example-motion/lcls-plc-example-motion.tsproj
-----------------------------------------------------------


mkdir -p "/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/.pytmc_build"
make[1]: Entering directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
* Found pytmc v2.19.1
<string>:1: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
A newer pytmc is required: >= 2.21.0
make[1]: *** [/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/ioc-common-ads-ioc/iocBoot/templates/Makefile.base:81: _check_versions] Error 1
make[1]: Leaving directory '/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example'
make: *** [/cds/home/z/zlentz/projects/ctrlenv_ecs-10013/ioc-common-ads-ioc/iocBoot/templates/Makefile.base:165: build] Error 2
```

</details>

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
