### PR TITLE
default DESC to PV name; bump IDLY default to 30

### DIFF
--- a/app/Db/tcmotor.template
+++ b/app/Db/tcmotor.template
@@ -10,14 +10,14 @@
 #   PREC     - Display precision (e.g. 3)
 
 record(tcmotor, "$(PREFIX)$(M)") {
-    field(DESC,  "$(DESC=TwinCAT Motor)")
+    field(DESC,  "$(DESC=$(PREFIX)$(M))")
     field(EGU,   "$(EGU=mm)")
     field(PREC,  "$(PREC=3)")
     field(PINI,  "YES")
     field(HLSV, "MAJOR")
     field(LLSV, "MAJOR")
     field(LSV,  "MAJOR")
-    field(IDLY,  "$(IDLY=5)")
+    field(IDLY,  "$(IDLY=30)")
 
     field(INP_RBV,  "$(PREFIX)$(M):fActPosition_RBV CP MS")
     field(INP_EGU,  "$(PREFIX)$(M):NC:Eu:Val_RBV CP MS")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Default DESC to PV name; bump IDLY default to 30

## Description
<!--- Describe your changes in detail -->
Two default-value changes in `app/Db/tcmotor.template`:

- **`DESC`** now defaults to the record's own PV name
  (`$(DESC=$(PREFIX)$(M))`) instead of the generic `"TwinCAT Motor"` string, so
  every motor instance has a unique, self-identifying description when no
  explicit `DESC` macro is supplied.
- **`IDLY`** default raised `5` → `30` seconds, giving ADS more time to connect
  before the deferred init callback seeds the output fields from the PLC `_RBV`
  readbacks.

Instances that pass `DESC=` or `IDLY=` explicitly are unaffected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The shared `"TwinCAT Motor"` default made every axis' `.DESC` identical and
  unhelpful in tools and alarm lists. Defaulting to the PV name makes each
  record self-describing.
- The longer `IDLY` avoids the init callback firing before ADS is ready on
  slower-connecting IOCs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Loaded the template for three axes on a test IOC (`TST:MOTION:M1..M3`) and
confirmed each `.DESC` resolves to its own PV name:

```
TST:MOTION:M1: val=1200.000 velo=50.000 vbas=2200.000 vmax=2000.000 accs=0.000 cnen=1 hlm=1100.000 llm=-1100.000 bdst=-5.000 off=0.000 twv=5.000
TST:MOTION:M2: val=300.000 velo=15.500 vbas=2200.000 vmax=2000.000 accs=0.000 cnen=1 hlm=0.000 llm=0.000 bdst=0.000 off=0.000 twv=2.500
TST:MOTION:M3: val=300.000 velo=15.500 vbas=2200.000 vmax=2000.000 accs=0.000 cnen=1 hlm=0.000 llm=0.000 bdst=0.000 off=0.000 twv=5.000

caget TST:MOTION:M1.DESC TST:MOTION:M2.DESC TST:MOTION:M3.DESC
TST:MOTION:M1.DESC             TST:MOTION:M1
TST:MOTION:M2.DESC             TST:MOTION:M2
TST:MOTION:M3.DESC             TST:MOTION:M3
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
The macro defaults are self-documenting in `app/Db/tcmotor.template`, alongside
the existing `Macros:` header comment describing `DESC` and `IDLY`.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
