### PR TITLE
Fix overall issues with tcmotor EGU rendering ( IOC & Typhos)

### DIFF
--- a/app/src/tcmotorRecord.c
+++ b/app/src/tcmotorRecord.c
@@ -1395,6 +1395,16 @@ static long get_units(DBADDR *paddr, char *units)
 {
     tcmotorRecord *prec = (tcmotorRecord *)paddr->precord;
 
+    /* Channel Access transports units in an 8-byte field (MAX_UNITS_SIZE),
+     * i.e. 7 usable characters plus the NUL -- much smaller than the record's
+     * 16-byte DB_UNITS_SIZE egu buffer. The derived velocity/accel strings add
+     * "/s" (2) and "/s^2" (4) suffixes, so a 6-char base like "Degree" overflows
+     * the CA limit and is silently truncated to "Degree/" on the wire. Abbreviate
+     * the long "Degree" spelling to "deg" so "deg/s" (5) and "deg/s^2" (7) fit. */
+    const char *base = prec->egu;
+    if (strcmp(prec->egu, "Degree") == 0)
+        base = "deg";
+
     if (paddr->pfield == (void *)&prec->val  ||
         paddr->pfield == (void *)&prec->rbv  ||
         paddr->pfield == (void *)&prec->hlm  ||
@@ -1402,13 +1412,13 @@ static long get_units(DBADDR *paddr, char *units)
         paddr->pfield == (void *)&prec->bdst ||
         paddr->pfield == (void *)&prec->off  ||
         paddr->pfield == (void *)&prec->hpos) {
-        strncpy(units, prec->egu, DB_UNITS_SIZE);
+        strncpy(units, base, DB_UNITS_SIZE);
     } else if (paddr->pfield == (void *)&prec->velo ||
                paddr->pfield == (void *)&prec->vbas ||
                paddr->pfield == (void *)&prec->vmax) {
-        snprintf(units, DB_UNITS_SIZE, "%s/s", prec->egu);
+        snprintf(units, DB_UNITS_SIZE, "%s/s", base);
     } else if (paddr->pfield == (void *)&prec->accs) {
-        snprintf(units, DB_UNITS_SIZE, "%s/s^2", prec->egu);
+        snprintf(units, DB_UNITS_SIZE, "%s/s^2", base);
     } else {
         units[0] = '\0';
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# tcmotorRecord: abbreviate "Degree" EGU so derived velocity/accel units fit Channel Access. 
**Note: the Degree symbol is not render into string by CA, so twincat rotary axes should use Degree for units.**

## Description
<!--- Describe your changes in detail -->
`get_units()` in `app/src/tcmotorRecord.c` derives the units of thevelocity/acceleration fields from the base position `EGU` by appending `/s`(VELO/VBAS/VMAX) and `/s^2` (ACCS). Channel Access transports units in an 8-byte field (`MAX_UNITS_SIZE`, i.e. 7 usable chars + NUL), which is much smaller than the record's 16-byte `DB_UNITS_SIZE` `egu` buffer. When the base EGU is the 6 char string `"Degree"`, the derived strings `"Degree/s"` (8) and `"Degree/s^2"` (10) exceed the CA limit and are silently truncated on the wire to `"Degree/"`, so screens show a meaningless trailing slash with no rate.

The fix abbreviates the `"Degree"` spelling to `"deg"` inside `get_units()`, so:

- position fields report `deg`
- VELO/VBAS/VMAX report `deg/s` (5 chars)
- ACCS reports `deg/s^2` (7 chars, fits exactly)

Only the CA-reported units string is affected; the stored `EGU` field and all other EGU values (e.g. `mm`, which already fits) are unchanged.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On rotary axes whose PLC engineering unit is `Degree`, Typhos displayed `0.000 Degree/` for velocity and acceleration instead of `Degree/s` and `Degree/s^2`, because the CA units field truncated the derived strings. This made the motion-parameter units ambiguous on screens.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built the record support and loaded a rotary axis whose `NC:Eu:Val_RBV` reports `Degree`, then confirmed the CA-reported units via `caget -d DBR_CTRL_DOUBLE`:

```
caget -S TST:MOTION:M1:NC:Eu:Val_RBV TST:MOTION:M2:NC:Eu:Val_RBV TST:MOTION:M3:NC:Eu:Val_RBV
TST:MOTION:M1:NC:Eu:Val_RBV Degree
TST:MOTION:M2:NC:Eu:Val_RBV mm
TST:MOTION:M3:NC:Eu:Val_RBV mm
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
A comment in `get_units()` explains the CA `MAX_UNITS_SIZE` limit and why `"Degree"` is abbreviated to `"deg"`.

<!--
## Screenshots (if appropriate):
-->
<img width="867" height="202" alt="image" src="https://github.com/user-attachments/assets/562bd5e2-eb17-41b5-beb9-15efdaeab27f" />
<img width="795" height="111" alt="image" src="https://github.com/user-attachments/assets/671c342a-d7a8-430a-bca7-814e4346e74c" />
<img width="796" height="35" alt="image" src="https://github.com/user-attachments/assets/a05f6c3e-a592-4838-bf92-9a777f33a97e" />
<img width="866" height="198" alt="image" src="https://github.com/user-attachments/assets/0c108c6f-98d2-4ec8-a895-a9e1b9c2dd5a" />
<img width="786" height="100" alt="image" src="https://github.com/user-attachments/assets/b19c997d-e1fc-4bce-9f13-1215855082c9" />

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API